### PR TITLE
Set correct priority for warning level messages

### DIFF
--- a/src/winston-journald3.ts
+++ b/src/winston-journald3.ts
@@ -73,6 +73,7 @@ export default class WinstonJournald extends TransportStream {
             case "error":
                 return SyslogPrority.ERROR;
             case "warning":
+            case "warn":
                 return SyslogPrority.WARN;
             case "notice":
                 return SyslogPrority.NOTICE;


### PR DESCRIPTION
Reference: https://github.com/winstonjs/winston#logging

I may be missing something, but seems like this function may need a full rewrite to properly map all winston logging level.